### PR TITLE
Fix remote addr option, use double dash

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,0 +1,44 @@
+name: Create and publish a Docker image
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ['master']
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@ if [ -n "$NGROK_REMOTE_ADDR" ]; then
     echo "You must specify an authentication token after registering at https://ngrok.com to use reserved ip addresses."
     exit 1
   fi
-  ARGS="$ARGS -remote-addr=$NGROK_REMOTE_ADDR "
+  ARGS="$ARGS --remote-addr=$NGROK_REMOTE_ADDR "
 fi
 
 # Set a custom region


### PR DESCRIPTION
<!-- Please include the story ID! -->
**Ticket(s):** https://app.shortcut.com/greenspace/story/50250/implement-analytics-contract-test-ci-check

### Summary
<!-- Provide a summary and any useful background context on *why* we're making this change. -->

The upstream docker image forked here does not handle --remote-addr options correctly. Patch it here until upstream is fixed.

### Design / Approach
<!-- Provide additional context if applicable, perhaps explaining why this approach was taken or what other approaches were considered. Remove this section if not applicable. -->

The goal here is to create a fixed image we can use which is controlled by our org.
It can be available via:
`docker pull ghcr.io/grnspace/docker-ngrok:SHA`

### Questions
<!-- Include outstanding questions/discussion points. Leverage markdown's numbered list to easily reference points! Remove this section if not applicable. -->



### Changes
<!-- List the major things added, changed, and fixed (the *what*). When listing changes, create them in the active tense for readability (e.g. add, remove, fix, update). -->

- [x]

### Screenshots
<!-- Include a screenshot if there's new or updated UI involved. Remove this section if not applicable. -->
